### PR TITLE
Move configuration outside deployment folder

### DIFF
--- a/lib/src/main/java/mz/org/fgh/hl7/lib/Constants.java
+++ b/lib/src/main/java/mz/org/fgh/hl7/lib/Constants.java
@@ -1,6 +1,12 @@
 package mz.org.fgh.hl7.lib;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 public interface Constants {
+    public static final Path APP_CONFIG_LOCATION = Paths
+            .get("C:\\Program Files\\Apache Software Foundation\\Tomcat 8.5\\conf\\hl7");
+    public static final String APPLICATION_PROPERTIES_ENC = "application.properties.enc";
     public static final String KEY_STORE_TYPE = "JCEKS";
     public static final String DISA_SECRET_KEY_ALIAS = "disaSecretKeyAlias";
     public static final String C_SAUDE_SECRET_KEY_ALIAS = "csaudeSecretKeyAlias";

--- a/web/src/main/java/mz/org/fgh/hl7/web/env/EncryptedEnvironmentLoader.java
+++ b/web/src/main/java/mz/org/fgh/hl7/web/env/EncryptedEnvironmentLoader.java
@@ -1,12 +1,16 @@
 package mz.org.fgh.hl7.web.env;
 
+import static mz.org.fgh.hl7.lib.Constants.APPLICATION_PROPERTIES_ENC;
+import static mz.org.fgh.hl7.lib.Constants.APP_CONFIG_LOCATION;
+
 import java.io.IOException;
+import java.nio.file.Path;
 
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.PropertySource;
-import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
 
@@ -35,18 +39,19 @@ public class EncryptedEnvironmentLoader
         HL7EncryptionServiceImpl encryptionService = new HL7EncryptionServiceImpl();
         EncryptedPropertySourceLoader loader = new EncryptedPropertySourceLoader(hl7KeyStoreService, encryptionService);
 
-        Resource path = new ClassPathResource("application.properties.enc");
-        PropertySource<?> propertySource = loadEncryptedProperties(loader, path);
+        Path path = APP_CONFIG_LOCATION.resolve(APPLICATION_PROPERTIES_ENC);
+        Resource resource = new FileSystemResource(path);
+        PropertySource<?> propertySource = loadEncryptedProperties(loader, resource);
 
         environment.getPropertySources().addFirst(propertySource);
     }
 
-    private PropertySource<?> loadEncryptedProperties(EncryptedPropertySourceLoader loader, Resource path) {
-        Assert.isTrue(path.exists(), () -> "Resource " + path + " does not exist");
+    private PropertySource<?> loadEncryptedProperties(EncryptedPropertySourceLoader loader, Resource resource) {
+        Assert.isTrue(resource.exists(), () -> "Resource " + resource + " does not exist");
         try {
-            return loader.load("custom-resource", path).get(0);
+            return loader.load("custom-resource", resource).get(0);
         } catch (IOException ex) {
-            throw new IllegalStateException("Failed to load configuration from " + path, ex);
+            throw new IllegalStateException("Failed to load configuration from " + resource, ex);
         }
     }
 }


### PR DESCRIPTION
Doing new deployments would cause application.properties.enc to be removed. This change moves the configuration to a folder outside the deployment folder in order to make it presistent across deploys.
Admins will need to run the configurer once before deploying or copy application.properties.enc to tomcat's conf/hl7 folder.